### PR TITLE
Add retries to apt cache update

### DIFF
--- a/tasks/openstack_host_install_apt.yml
+++ b/tasks/openstack_host_install_apt.yml
@@ -39,6 +39,10 @@
   apt:
     update_cache: yes
   when: "ansible_date_time.epoch|float - apt_cache_stat.stat.mtime > {{cache_timeout}}"
+  register: update_apt_cache
+  until: update_apt_cache | success
+  retries: 5
+  delay: 2
   tags:
     - openstack-apt-packages
 


### PR DESCRIPTION
Updating the apt cache sometimes fails due to it being
an operation that uses mirrors on the internet. The
task should be retried to reduce the chance of a
transient failure causing the playbook to fail.

Change-Id: Ib879989a839a77135ba48720d27e981d80931b0d
Partial-Bug: #1750656