### PR TITLE
Fix for ubuntu kernel extra modules package name change

### DIFF
--- a/vars/ubuntu-14.04.yml
+++ b/vars/ubuntu-14.04.yml
@@ -69,7 +69,7 @@ openstack_host_distro_packages:
   - irqbalance
   - libkmod-dev
   - libkmod2
-  - linux-image-extra-{{ ansible_kernel }}
+  - "{% if hostvars[inventory_hostname]['ansible_kernel'] | version_compare('3.13.0-166', '>=') %}linux-modules-extra-{{ ansible_kernel }}{% else %}linux-image-extra-{{ ansible_kernel }}{% endif %}"
   - lvm2
   - python-software-properties
   - python-dev

--- a/vars/ubuntu-16.04.yml
+++ b/vars/ubuntu-16.04.yml
@@ -64,7 +64,7 @@ openstack_host_distro_packages:
   - irqbalance
   - libkmod-dev
   - libkmod2
-  - linux-image-extra-{{ ansible_kernel }}
+  - "{% if hostvars[inventory_hostname]['ansible_kernel'] | version_compare('4.4.0-143', '>=') %}linux-modules-extra-{{ ansible_kernel }}{% else %}linux-image-extra-{{ ansible_kernel }}{% endif %}"
   - lvm2
   - python-software-properties
   - python-dev


### PR DESCRIPTION
Ubuntu has changed the name of its kernel extra modules package
from linux-image-extra to linux-modules-extra.  These vars mods
should account for the change.